### PR TITLE
Document assistant dev mode orchestration

### DIFF
--- a/cli/task-agent.mdx
+++ b/cli/task-agent.mdx
@@ -5,9 +5,17 @@ description: 'Create and manage LibOps Task Agent tasks from sitectl'
 
 Task Agent commands run LibOps coding-agent work from the terminal.
 
-The current LibOps Task Agent harness is Codex. Supported harnesses are documented in the [`libops/cli-sandbox`](https://github.com/libops/cli-sandbox) project.
+Supported harnesses are `codex`, `claude`, `pi`, `opencode`, and `gemini`. They run through the [`libops/cli-sandbox`](https://github.com/libops/cli-sandbox) image.
 
 The default model is `glm-5.2:cloud`. `kimi-k2.6` is also supported. They run inside your organization's infrastructure on the LibOps-managed platform, with access limited to members of your organization. LibOps evaluates new open weight models as they become available. Contact [LibOps](https://www.libops.io/contact/) if your organization wants to integrate with Anthropic, OpenAI, or another model provider.
+
+For site coding tasks, the runner prepares the checked-out Compose project with sitectl before the agent starts:
+
+```bash
+sitectl set dev-mode enabled --assistant --harness codex --compose-access --yolo
+```
+
+That writes the plugin-owned development mounts and a profiled `cli-sandbox` service into `docker-compose.override.yml`, so the agent sees the same editable code paths that local dev mode uses.
 
 ## Create
 

--- a/docs.json
+++ b/docs.json
@@ -97,7 +97,8 @@
             "group": "Commands",
             "pages": [
               "cli/compose",
-              "cli/port-forwarding"
+              "cli/port-forwarding",
+              "cli/task-agent"
             ]
           },
           {

--- a/platform/coding-agent-workflow.mdx
+++ b/platform/coding-agent-workflow.mdx
@@ -13,11 +13,19 @@ The default model is `glm-5.2:cloud`. `kimi-k2.6` is also supported, and LibOps 
 
 ## Models and execution boundary
 
-The current LibOps Task Agent harness is Codex. Supported harnesses are documented in the [`libops/cli-sandbox`](https://github.com/libops/cli-sandbox) project.
+The LibOps Task Agent can run `codex`, `claude`, `pi`, `opencode`, or `gemini` through the [`libops/cli-sandbox`](https://github.com/libops/cli-sandbox) image.
 
 The supported models run inside your organization's infrastructure on the LibOps-managed platform. Only members of your organization can access the infrastructure serving those models.
 
 Contact [LibOps](https://www.libops.io/contact/) if your organization wants to integrate with Anthropic, OpenAI, or another model provider.
+
+For site coding tasks, the runner prepares the checked-out repository with sitectl before the harness starts:
+
+```bash
+sitectl set dev-mode enabled --assistant --harness codex --compose-access --yolo
+```
+
+That step writes the application plugin's editable-code mounts and a profiled `cli-sandbox` service into `docker-compose.override.yml`. The agent then works against the same development surface that engineers use locally, including app-specific paths such as Drupal modules and themes, WordPress plugins and themes, OJS plugins, and Omeka modules or themes.
 
 ## Why use the LibOps Task Agent?
 

--- a/snippets/task-agent.mdx
+++ b/snippets/task-agent.mdx
@@ -9,4 +9,4 @@ The **LibOps Task Agent** does the technical work. Your team reviews every chang
 
 Every change is transparent, reviewable, and tied to the GitHub workflow your team already knows.
 
-The default model is `glm-5.2:cloud`. `kimi-k2.6` is also supported. They run inside your organization's infrastructure on the LibOps-managed platform, with access limited to members of your organization. LibOps evaluates new open weight models as they become available.
+The default model is `glm-5.2:cloud`. `kimi-k2.6` is also supported. Harnesses run through `libops/cli-sandbox`, and site coding tasks are prepared with `sitectl set dev-mode --assistant` so the agent sees the same plugin-owned development mounts as a local engineer. Models run inside your organization's infrastructure on the LibOps-managed platform, with access limited to members of your organization. LibOps evaluates new open weight models as they become available.

--- a/templates/app-support.mdx
+++ b/templates/app-support.mdx
@@ -110,6 +110,8 @@ Template repositories are the customer-facing extension layer. Customers consume
 
 For local development, `sitectl compose up` may write an untracked `docker-compose.override.yml` to avoid host port conflicts. The tracked Compose file should publish the production ingress ports, usually `80:80` and, when the stack serves HTTPS directly, `443:443`. If production uses HTTPS and local development should match it, use mkcert-backed Traefik certificates rather than committing a TLS override.
 
+Application plugins also own their dev-mode mount list. `sitectl set dev-mode enabled` writes those mounts for local editing, and `sitectl set dev-mode --assistant` adds a profiled `cli-sandbox` service with the same plugin-declared code paths. Use `--compose-access` only when the coding agent should reach the running Compose network and host Docker daemon.
+
 This split keeps upstream downloads, checksums, PHP flavors, nginx runtime config, and install smoke tests centralized in buildkit while still giving customer repositories a small, understandable customization surface.
 
 ## Make Targets


### PR DESCRIPTION
## Summary
- document cli-sandbox-backed task agents and supported harnesses
- describe sitectl assistant dev-mode setup for code-change workflows
- add the task-agent CLI doc to navigation

## Tests
- not run; documentation only