### PR TITLE
[patch] Document API provider publication

### DIFF
--- a/infrastructure/release-compatibility.mdx
+++ b/infrastructure/release-compatibility.mdx
@@ -120,17 +120,57 @@ gate fails for malformed, empty, failed, cancelled, or skipped dependencies and
 has no checkout, package, OIDC, secret, or registry permission. The main-only
 publisher remains a separate caller job.
 
-The target API repository publication gives every built image a
-GHCR copy. Images consumed by LibOps GCP runtimes also receive a GAR copy:
-`api` (also tagged as `dash`), `api-vault-agent`, and `control-plane` use the
-private API-project repository; `terraform-runner`, `gcp-vm-ip-controller`,
-`controller-ingress`, and `site-controller` use shared public GAR; and
-`cloudflare-ingress-router` uses the separate shared-infrastructure GAR
-repository. The API workflow does not publish `api-init` or `vault-server`.
-A successful publication uses one
+The target API repository publication gives every deployable image a GHCR
+copy. Images consumed by LibOps GCP runtimes also receive a GAR copy:
+`api` (also tagged as `dash`), `api-init`, `api-vault-agent`, and
+`control-plane` use the private API-project repository; `terraform-runner`,
+`gcp-vm-ip-controller`, `controller-ingress`, and `site-controller` use shared
+public GAR; and `cloudflare-ingress-router` uses the separate
+shared-infrastructure GAR repository. The independently owned `vault-server`
+image is not built or published by the API workflow.
+
+The Terraform runner has a separate provider-mirror build path so one large
+provider build does not hide which provider failed or exhaust one native
+runner. It divides the pinned Terraform providers into three lanes:
+
+| Provider lane | Contents |
+| --- | --- |
+| `google` | Google provider |
+| `google-beta` | Google Beta provider |
+| `auxiliary` | Vault, Cloudflare, and Time providers |
+
+On a pull request, each lane is built and scanned separately for native
+`linux/amd64` and `linux/arm64`. The jobs do not receive package, GAR, or OIDC
+publisher authority. They upload one-day, run-ID-scoped mirror artifacts, and
+the matching architecture's Terraform-runner job downloads only artifacts
+from that workflow run. It validates the exact allowlisted files, executable
+modes, ELF architectures, Go toolchain, and security-sensitive dependency
+versions before assembling the runner. The completed runner then proves that
+each embedded stack can initialize and validate without downloading providers.
+These artifacts are an internal handoff between credential-free PR jobs, not
+published packages or a release channel.
+
+After required CI succeeds for the exact current `main` commit, the protected
+publisher builds the same three multi-platform lanes. Their intermediate
+images are GHCR-only, scanned and keylessly signed build products named
+`terraform-providers-google`, `terraform-providers-google-beta`, and
+`terraform-providers-auxiliary`. The workflow uses the stable
+`sha-<40-character-commit>-run-<workflow-run-id>-provider` selector for those
+three intermediates. Before building the final runner, it resolves each
+intermediate to an immutable digest, requires exactly the expected amd64 and
+arm64 manifests and distinct digests, verifies each keyless signature against
+the pinned shared publisher identity, and confirms that the selected commit is
+still current `main`. Only those verified digest references enter the final
+Terraform-runner build.
+
+The deployable images, including the final `terraform-runner`, use the
 `sha-<40-character-commit>-run-<workflow-run-id>-attempt-<workflow-attempt>`
-selector across its set, but deployment resolves each name independently and
-passes only digest references.
+selector. The runner is scanned, signed, and published to both GHCR and shared
+public GAR. Deployment resolves every deployable image name independently and
+passes only digest references; it does not deploy or pin the intermediate
+provider images. These signatures bind the reviewed publisher identity to the
+published digests. They are not SLSA provenance or an attestation of the full
+build-material graph.
 
 Before this API publication path can be promoted, the admin plugin must resolve
 every selected API bundle image and the independently released Vault server to


### PR DESCRIPTION
Documents the API image registry map and the credential-free PR, signed provider-lane, immutable-digest, and final Terraform runner publication boundaries. Corrects the api-init GAR contract and avoids provenance overclaims.